### PR TITLE
Add Initial CLI/Automation features

### DIFF
--- a/args.go
+++ b/args.go
@@ -15,6 +15,7 @@ type Arguments struct {
 	Timeout    int
 	Verbosity  int
 	TlsLogPath string
+	CliMode    bool
 }
 
 func parseArguments() Arguments {
@@ -26,6 +27,7 @@ func parseArguments() Arguments {
 	flag.IntVar(&args.Threads, "t", 1, "The number of threads to use for running tests. Defaults to 1.")
 	flag.IntVar(&args.Timeout, "o", 5, "The timeout for API requests. Defaults to 5 seconds.")
 	flag.StringVar(&args.TlsLogPath, "tls-log", "", "Enable and log the TLS key to the path specified.")
+	flag.BoolVar(&args.CliMode, "c", false, "Enable cli mode for use in pipelines and automations. Defaults to false.")
 
 	// Custom parsing for verbosity
 	var vFlag, vvFlag bool

--- a/cliModeUtils.go
+++ b/cliModeUtils.go
@@ -1,0 +1,13 @@
+package main
+
+import "os"
+
+func cliExit(numFailedTests int) {
+	// Exit with an error if at least one
+	// test failed.
+	if numFailedTests > 0 {
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}

--- a/main.go
+++ b/main.go
@@ -20,4 +20,8 @@ func main() {
 	}
 
 	printSummary(numTests, numFailedTests, numWarnTests)
+
+	if args.CliMode {
+		cliExit(numFailedTests)
+	}
 }


### PR DESCRIPTION
Added new argument `-c` which runs the utility in a cli/headless/automation mode where it will exit with a 0 when all tests pass or exit with a 1 if at least one test fails. This makes it convenient to use in CI pipelines and other automations.